### PR TITLE
state_legislative_districts is an object, not an array

### DIFF
--- a/geocodio-api.yml
+++ b/geocodio-api.yml
@@ -431,18 +431,16 @@ components:
           source:
             type: string
     FieldStateLegislativeDistricts:
-      type: array
-      items:
-        type: object
-        properties:
-          senate:
-            type: array
-            items:
-              $ref: '#/components/schemas/FieldStateLegislativeDistrict'
-          house:
-            type: array
-            items:
-              $ref: '#/components/schemas/FieldStateLegislativeDistrict'
+      type: object
+      properties:
+        senate:
+          type: array
+          items:
+            $ref: '#/components/schemas/FieldStateLegislativeDistrict'
+        house:
+          type: array
+          items:
+            $ref: '#/components/schemas/FieldStateLegislativeDistrict'
     FieldStateLegislativeDistrict:
       type: object
       properties:


### PR DESCRIPTION
I've started working with your API recently, generating client code using your OpenAPI spec, and I found an issue. This edit brings the OpenAPI spec in line with the actual stateleg data I receive. See also the example data here: https://www.geocod.io/docs/#data-appends-fields